### PR TITLE
feat: add mitigating signals for human behavioral patterns

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -140,4 +140,56 @@ export const CONFIG = {
   PRE_AI_REPOS_HIGH: 8,                  // >= 8 qualifying repos = high mitigation
   POINTS_PRE_AI_REPOS: 10,
   POINTS_PRE_AI_REPOS_HIGH: 20,
+
+  // Outbound PR review mitigating signal (reviewing others' code)
+  REVIEW_EVENTS_BASE: 5,
+  REVIEW_EVENTS_HIGH: 15,
+  POINTS_REVIEW_ACTIVITY: 5,
+  POINTS_REVIEW_ACTIVITY_HIGH: 10,
+
+  // Inline PR review comment mitigating signal (reading diffs and commenting on specific lines)
+  REVIEW_COMMENT_EVENTS_BASE: 3,
+  REVIEW_COMMENT_EVENTS_HIGH: 10,
+  POINTS_REVIEW_COMMENTS: 5,
+  POINTS_REVIEW_COMMENTS_HIGH: 10,
+
+  // Follower count mitigating signal (organic social proof — hard to inflate post-2022)
+  FOLLOWERS_BASE: 50,
+  FOLLOWERS_HIGH: 200,
+  POINTS_FOLLOWERS_BASE: 5,
+  POINTS_FOLLOWERS_HIGH: 10,
+
+  // Identity completeness mitigating signal (full profile = high friction for bot farms)
+  IDENTITY_FIELDS_BASE: 3,
+  IDENTITY_FIELDS_ALL: 5,
+  IDENTITY_BIO_MIN_LENGTH: 20,
+  POINTS_IDENTITY_BASE: 5,
+  POINTS_IDENTITY_HIGH: 10,
+
+  // Activity dormancy gap mitigating signal (bots don't take breaks)
+  DORMANCY_GAP_DAYS: 30,
+  DORMANCY_GAP_LONG_DAYS: 60,
+  POINTS_DORMANCY_GAP: 5,
+  POINTS_DORMANCY_GAP_LONG: 10,
+
+  // Gist activity mitigating signal (personal utility, zero spam value for bots)
+  POINTS_GIST_ACTIVITY: 5,
+
+  // PR iteration cycle mitigating signal (synchronize = author responded to review feedback)
+  PR_SYNC_REPOS_BASE: 2,
+  PR_SYNC_REPOS_HIGH: 5,
+  POINTS_PR_SYNC_BASE: 5,
+  POINTS_PR_SYNC_HIGH: 10,
+
+  // Long-span repo engagement mitigating signal (returning to same repo over 4+ months)
+  REPO_SPAN_MIN_DAYS: 120,
+  REPO_SPAN_BASE_COUNT: 2,
+  REPO_SPAN_HIGH_COUNT: 4,
+  POINTS_REPO_SPAN_BASE: 5,
+  POINTS_REPO_SPAN_HIGH: 10,
+
+  // Day-of-week variance mitigating signal (human rest patterns; uniform distribution is a bot tell)
+  DOW_EVENTS_MIN: 20,
+  DOW_VARIANCE_CV_MIN: 0.3,
+  POINTS_DOW_VARIANCE: 5,
 } as const;

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,4 +120,24 @@ export const CONFIG = {
   BRANCH_PR_PATTERN_RATIO_MIN_ESTABLISHED: 0.8, // stricter ratio for established (80%)
   BRANCH_PR_COUNT_RATIO_MIN: 0.65, // branches/PRs ratio must be >= this (low ratio = legitimate dev with many unrelated PRs)
   POINTS_BRANCH_PR_AUTOMATION: 35, // strong automation indicator
+
+  // Merged external PR mitigating signals (third-party human attestation)
+  // A merged PR requires a different account to accept the work
+  MERGED_PR_REPOS_MIN: 3,                   // >= 3 distinct repos with merged PRs
+  MERGED_PR_REPOS_HIGH: 8,                  // >= 8 distinct repos with merged PRs
+  POINTS_ESTABLISHED_CONTRIBUTOR: 10,       // negative flag points for 3–7 repos
+  POINTS_ESTABLISHED_CONTRIBUTOR_HIGH: 20,  // negative flag points for 8+ repos
+
+  // Account age mitigating signals (accounts predating the AI coding wave)
+  AGE_SENIOR_ACCOUNT: 1095,              // 3+ years old (~pre-2023)
+  AGE_VETERAN_ACCOUNT: 1825,             // 5+ years old (~pre-2021)
+  POINTS_SENIOR_ACCOUNT_MITIGATION: 10,
+  POINTS_VETERAN_ACCOUNT_MITIGATION: 20,
+
+  // Repos created before the AI era (evidence of pre-AI development history)
+  PRE_AI_REPOS_YEAR: 2025,               // repos created before this year qualify
+  PRE_AI_REPOS_MIN: 3,                   // >= 3 qualifying repos = base mitigation
+  PRE_AI_REPOS_HIGH: 8,                  // >= 8 qualifying repos = high mitigation
+  POINTS_PRE_AI_REPOS: 10,
+  POINTS_PRE_AI_REPOS_HIGH: 20,
 } as const;

--- a/src/identify-replicant.ts
+++ b/src/identify-replicant.ts
@@ -67,6 +67,7 @@ export function identifyReplicant({
   reposCount,
   accountName,
   events,
+  repos,
 }: IdentifyReplicantOptions): IdentifyReplicantResult {
   const flags: IdentifyFlag[] = [];
 
@@ -832,11 +833,82 @@ export function identifyReplicant({
         detail: `${Math.round(foreignRatio * 100)}% of activity on other people's repos`,
       });
     }
+
+  }
+
+  // Merged external PR mitigating signal: a merged PR requires a human maintainer on the other side — third-party attestation that's hard to fake at scale
+  if (events.length >= CONFIG.MIN_EVENTS_FOR_ANALYSIS) {
+    const userLogin = accountName.toLowerCase();
+    const mergedExternalRepos = new Set<string>();
+    for (const e of events) {
+      if (e.type !== "PullRequestEvent") continue;
+      const repoOwner = e.repo?.name?.split("/")[0]?.toLowerCase();
+      if (!repoOwner || repoOwner === userLogin) continue;
+      const isMergedPR =
+        e.payload?.action === "merged" ||
+        (e.payload?.action === "closed" &&
+          (e.payload?.pull_request as { merged?: boolean } | undefined)
+            ?.merged === true);
+      if (isMergedPR) {
+        const repo = e.repo?.name;
+        if (repo) mergedExternalRepos.add(repo.toLowerCase());
+      }
+    }
+
+    if (mergedExternalRepos.size >= CONFIG.MERGED_PR_REPOS_HIGH) {
+      flags.push({
+        label: "Accepted contributions across many repos",
+        points: -CONFIG.POINTS_ESTABLISHED_CONTRIBUTOR_HIGH,
+        detail: `${mergedExternalRepos.size} different repos merged their PRs`,
+      });
+    } else if (mergedExternalRepos.size >= CONFIG.MERGED_PR_REPOS_MIN) {
+      flags.push({
+        label: "Accepted contributions across repos",
+        points: -CONFIG.POINTS_ESTABLISHED_CONTRIBUTOR,
+        detail: `${mergedExternalRepos.size} different repos merged their PRs`,
+      });
+    }
+  }
+
+  // Account age mitigating signal: AI-seeded bots are almost exclusively post-2022; 3+ year accounts predate the wave and are structurally unlikely to be AI-seeded
+  if (accountAge >= CONFIG.AGE_VETERAN_ACCOUNT) {
+    flags.push({
+      label: "Long-standing account",
+      points: -CONFIG.POINTS_VETERAN_ACCOUNT_MITIGATION,
+      detail: `Account is ${accountAge} days old (5+ years)`,
+    });
+  } else if (accountAge >= CONFIG.AGE_SENIOR_ACCOUNT) {
+    flags.push({
+      label: "Established account",
+      points: -CONFIG.POINTS_SENIOR_ACCOUNT_MITIGATION,
+      detail: `Account is ${accountAge} days old (3+ years)`,
+    });
+  }
+
+  // Pre-AI repo mitigating signal: bots almost never have repos predating 2025; requires caller to pass repos from GET /users/{username}/repos
+  if (repos && repos.length > 0) {
+    const preAiRepoCount = repos.filter(
+      (r) => new Date(r.created_at).getFullYear() < CONFIG.PRE_AI_REPOS_YEAR,
+    ).length;
+
+    if (preAiRepoCount >= CONFIG.PRE_AI_REPOS_HIGH) {
+      flags.push({
+        label: "Pre-AI development history",
+        points: -CONFIG.POINTS_PRE_AI_REPOS_HIGH,
+        detail: `${preAiRepoCount} repos created before ${CONFIG.PRE_AI_REPOS_YEAR}`,
+      });
+    } else if (preAiRepoCount >= CONFIG.PRE_AI_REPOS_MIN) {
+      flags.push({
+        label: "Pre-AI activity",
+        points: -CONFIG.POINTS_PRE_AI_REPOS,
+        detail: `${preAiRepoCount} repos created before ${CONFIG.PRE_AI_REPOS_YEAR}`,
+      });
+    }
   }
 
   // Invert score: 100 = human, 0 = bot
   const score = flags.reduce((total, flag) => (total += flag.points), 0);
-  const humanScore = Math.max(0, 100 - score);
+  const humanScore = Math.min(100, Math.max(0, 100 - score));
 
   // Classification based on inverted score
   let classification: IdentityClassification = "automation";

--- a/src/identify-replicant.ts
+++ b/src/identify-replicant.ts
@@ -68,6 +68,7 @@ export function identifyReplicant({
   accountName,
   events,
   repos,
+  profile,
 }: IdentifyReplicantOptions): IdentifyReplicantResult {
   const flags: IdentifyFlag[] = [];
 
@@ -903,6 +904,218 @@ export function identifyReplicant({
         points: -CONFIG.POINTS_PRE_AI_REPOS,
         detail: `${preAiRepoCount} repos created before ${CONFIG.PRE_AI_REPOS_YEAR}`,
       });
+    }
+  }
+
+  // Outbound PR review mitigating signal: reviewing others' code means reading diffs you didn't write and making a judgment call — bots submit PRs, they don't review them
+  if (events.length >= CONFIG.MIN_EVENTS_FOR_ANALYSIS) {
+    const userLogin = accountName.toLowerCase();
+    let reviewCount = 0;
+    for (const e of events) {
+      if (e.type !== "PullRequestReviewEvent") continue;
+      const repoOwner = e.repo?.name?.split("/")[0]?.toLowerCase();
+      if (!repoOwner || repoOwner === userLogin) continue;
+      reviewCount++;
+    }
+    if (reviewCount >= CONFIG.REVIEW_EVENTS_HIGH) {
+      flags.push({
+        label: "Active code reviewer",
+        points: -CONFIG.POINTS_REVIEW_ACTIVITY_HIGH,
+        detail: `${reviewCount} outbound code reviews on others' PRs`,
+      });
+    } else if (reviewCount >= CONFIG.REVIEW_EVENTS_BASE) {
+      flags.push({
+        label: "Code review contributor",
+        points: -CONFIG.POINTS_REVIEW_ACTIVITY,
+        detail: `${reviewCount} outbound code reviews on others' PRs`,
+      });
+    }
+  }
+
+  // Inline review comment mitigating signal: inline diff comments require reading specific code lines — cognitively expensive at scale
+  if (events.length >= CONFIG.MIN_EVENTS_FOR_ANALYSIS) {
+    const userLogin = accountName.toLowerCase();
+    let reviewCommentCount = 0;
+    for (const e of events) {
+      if (e.type !== "PullRequestReviewCommentEvent") continue;
+      const repoOwner = e.repo?.name?.split("/")[0]?.toLowerCase();
+      if (!repoOwner || repoOwner === userLogin) continue;
+      reviewCommentCount++;
+    }
+    if (reviewCommentCount >= CONFIG.REVIEW_COMMENT_EVENTS_HIGH) {
+      flags.push({
+        label: "Frequent inline reviewer",
+        points: -CONFIG.POINTS_REVIEW_COMMENTS_HIGH,
+        detail: `${reviewCommentCount} inline review comments on others' code`,
+      });
+    } else if (reviewCommentCount >= CONFIG.REVIEW_COMMENT_EVENTS_BASE) {
+      flags.push({
+        label: "Inline code reviewer",
+        points: -CONFIG.POINTS_REVIEW_COMMENTS,
+        detail: `${reviewCommentCount} inline review comments on others' code`,
+      });
+    }
+  }
+
+  // Follower count mitigating signal: organic GitHub followers accumulate through real work and are hard to inflate post-2022
+  if (profile?.followers !== undefined) {
+    if (profile.followers >= CONFIG.FOLLOWERS_HIGH) {
+      flags.push({
+        label: "Established community presence",
+        points: -CONFIG.POINTS_FOLLOWERS_HIGH,
+        detail: `${profile.followers} GitHub followers`,
+      });
+    } else if (profile.followers >= CONFIG.FOLLOWERS_BASE) {
+      flags.push({
+        label: "Community presence",
+        points: -CONFIG.POINTS_FOLLOWERS_BASE,
+        detail: `${profile.followers} GitHub followers`,
+      });
+    }
+  }
+
+  // Identity completeness mitigating signal: maintaining a full, non-generic profile is high friction for a bot farm
+  if (profile) {
+    const filledFields = [
+      profile.name,
+      profile.company,
+      profile.location,
+      profile.bio,
+      profile.blog,
+    ].filter((f) => f && (f as string).trim().length > 0).length;
+    const hasRichBio =
+      (profile.bio?.trim().length ?? 0) >= CONFIG.IDENTITY_BIO_MIN_LENGTH;
+    if (filledFields >= CONFIG.IDENTITY_FIELDS_ALL && hasRichBio) {
+      flags.push({
+        label: "Complete developer identity",
+        points: -CONFIG.POINTS_IDENTITY_HIGH,
+        detail: `All ${filledFields} profile fields filled with substantive content`,
+      });
+    } else if (filledFields >= CONFIG.IDENTITY_FIELDS_BASE) {
+      flags.push({
+        label: "Established developer identity",
+        points: -CONFIG.POINTS_IDENTITY_BASE,
+        detail: `${filledFields} of 5 profile fields filled`,
+      });
+    }
+  }
+
+  // Activity dormancy gap mitigating signal: bots run 24/7 because idle time is wasted infrastructure cost; real hiatuses are a human pattern
+  if (events.length >= CONFIG.MIN_EVENTS_FOR_ANALYSIS) {
+    const timestamps = [...events]
+      .map((e) => new Date(e.created_at).getTime())
+      .filter((t) => !isNaN(t))
+      .sort((a, b) => a - b);
+    let maxGapDays = 0;
+    for (let i = 1; i < timestamps.length; i++) {
+      const gap = (timestamps[i] - timestamps[i - 1]) / (1000 * 60 * 60 * 24);
+      if (gap > maxGapDays) maxGapDays = gap;
+    }
+    if (maxGapDays >= CONFIG.DORMANCY_GAP_LONG_DAYS) {
+      flags.push({
+        label: "Extended activity hiatus",
+        points: -CONFIG.POINTS_DORMANCY_GAP_LONG,
+        detail: `${Math.round(maxGapDays)}-day activity gap (bots don't take breaks)`,
+      });
+    } else if (maxGapDays >= CONFIG.DORMANCY_GAP_DAYS) {
+      flags.push({
+        label: "Activity hiatus",
+        points: -CONFIG.POINTS_DORMANCY_GAP,
+        detail: `${Math.round(maxGapDays)}-day activity gap`,
+      });
+    }
+  }
+
+  // Gist activity mitigating signal: gists serve personal utility with zero spam value — bots have no incentive to create them
+  if (events.some((e) => e.type === "GistEvent")) {
+    flags.push({
+      label: "Gist activity",
+      points: -CONFIG.POINTS_GIST_ACTIVITY,
+      detail: "Gists indicate personal utility use, not automated behavior",
+    });
+  }
+
+  // PR iteration cycle mitigating signal: synchronize events on external PRs = author responded to reviewer feedback
+  if (events.length >= CONFIG.MIN_EVENTS_FOR_ANALYSIS) {
+    const userLogin = accountName.toLowerCase();
+    const syncRepos = new Set<string>();
+    for (const e of events) {
+      if (e.type !== "PullRequestEvent" || e.payload?.action !== "synchronize")
+        continue;
+      const repoOwner = e.repo?.name?.split("/")[0]?.toLowerCase();
+      if (!repoOwner || repoOwner === userLogin) continue;
+      const repo = e.repo?.name;
+      if (repo) syncRepos.add(repo.toLowerCase());
+    }
+    if (syncRepos.size >= CONFIG.PR_SYNC_REPOS_HIGH) {
+      flags.push({
+        label: "Active PR iteration across many repos",
+        points: -CONFIG.POINTS_PR_SYNC_HIGH,
+        detail: `Updated open PRs in ${syncRepos.size} repos in response to feedback`,
+      });
+    } else if (syncRepos.size >= CONFIG.PR_SYNC_REPOS_BASE) {
+      flags.push({
+        label: "Active PR iteration",
+        points: -CONFIG.POINTS_PR_SYNC_BASE,
+        detail: `Updated open PRs in ${syncRepos.size} repos in response to feedback`,
+      });
+    }
+  }
+
+  // Long-span repo engagement mitigating signal: returning to the same repo 4+ months later signals investment in a project, not a drive-by fork
+  if (events.length >= CONFIG.MIN_EVENTS_FOR_ANALYSIS) {
+    const repoSpans = new Map<string, { min: number; max: number }>();
+    for (const e of events) {
+      const repo = e.repo?.name;
+      if (!repo) continue;
+      const t = new Date(e.created_at).getTime();
+      if (isNaN(t)) continue;
+      const span = repoSpans.get(repo);
+      if (!span) {
+        repoSpans.set(repo, { min: t, max: t });
+      } else {
+        span.min = Math.min(span.min, t);
+        span.max = Math.max(span.max, t);
+      }
+    }
+    let longSpanCount = 0;
+    for (const { min, max } of repoSpans.values()) {
+      if ((max - min) / (1000 * 60 * 60 * 24) >= CONFIG.REPO_SPAN_MIN_DAYS)
+        longSpanCount++;
+    }
+    if (longSpanCount >= CONFIG.REPO_SPAN_HIGH_COUNT) {
+      flags.push({
+        label: "Deep long-term project engagement",
+        points: -CONFIG.POINTS_REPO_SPAN_HIGH,
+        detail: `${longSpanCount} repos with 4+ months of consistent engagement`,
+      });
+    } else if (longSpanCount >= CONFIG.REPO_SPAN_BASE_COUNT) {
+      flags.push({
+        label: "Long-term project engagement",
+        points: -CONFIG.POINTS_REPO_SPAN_BASE,
+        detail: `${longSpanCount} repos with 4+ months of consistent engagement`,
+      });
+    }
+  }
+
+  // Day-of-week variance mitigating signal: humans have uneven weekly patterns; perfectly uniform distribution is a bot tell
+  if (events.length >= CONFIG.DOW_EVENTS_MIN) {
+    const dowCounts = new Array<number>(7).fill(0);
+    for (const e of events) {
+      const t = new Date(e.created_at);
+      if (!isNaN(t.getTime())) dowCounts[t.getDay()]++;
+    }
+    const mean = dowCounts.reduce((a, b) => a + b, 0) / 7;
+    if (mean > 0) {
+      const variance =
+        dowCounts.reduce((sum, c) => sum + (c - mean) ** 2, 0) / 7;
+      if (Math.sqrt(variance) / mean >= CONFIG.DOW_VARIANCE_CV_MIN) {
+        flags.push({
+          label: "Human activity patterns",
+          points: -CONFIG.POINTS_DOW_VARIANCE,
+          detail: "Uneven day-of-week activity distribution suggests natural rest cycles",
+        });
+      }
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,14 @@ export type IdentifyReplicantOptions = {
   accountName: string;
   events: GitHubEvent[];
   repos?: Array<{ created_at: string }>;
+  profile?: {
+    followers?: number;
+    name?: string | null;
+    company?: string | null;
+    location?: string | null;
+    bio?: string | null;
+    blog?: string | null;
+  };
 };
 
 export type IdentityClassification = "organic" | "mixed" | "automation";

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type IdentifyReplicantOptions = {
   reposCount: number;
   accountName: string;
   events: GitHubEvent[];
+  repos?: Array<{ created_at: string }>;
 };
 
 export type IdentityClassification = "organic" | "mixed" | "automation";

--- a/test/__snapshots__/signals.test.ts.snap
+++ b/test/__snapshots__/signals.test.ts.snap
@@ -19,30 +19,40 @@ exports[`Signals > analysis 'automation/joannwalsh' 1`] = `
       "label": "Multiple forks",
       "points": 26,
     },
+    {
+      "detail": "Account is 1097 days old (3+ years)",
+      "label": "Established account",
+      "points": -10,
+    },
   ],
   "profile": {
-    "age": 1096,
+    "age": 1097,
     "repos": 134,
   },
-  "score": 0,
+  "score": 9,
 }
 `;
 
 exports[`Signals > analysis 'automation/reedpurdy' 1`] = `
 {
-  "classification": "automation",
+  "classification": "mixed",
   "flags": [
     {
       "detail": "13 repos forked within 24 hours",
       "label": "Many recent forks",
       "points": 51,
     },
+    {
+      "detail": "Account is 1372 days old (3+ years)",
+      "label": "Established account",
+      "points": -10,
+    },
   ],
   "profile": {
     "age": 1372,
     "repos": 125,
   },
-  "score": 49,
+  "score": 59,
 }
 `;
 
@@ -57,7 +67,7 @@ exports[`Signals > analysis 'automation/sheilaleffler' 1`] = `
     },
   ],
   "profile": {
-    "age": 396,
+    "age": 397,
     "repos": 31,
   },
   "score": 65,
@@ -67,9 +77,20 @@ exports[`Signals > analysis 'automation/sheilaleffler' 1`] = `
 exports[`Signals > analysis 'user/claudiaschoen' 1`] = `
 {
   "classification": "organic",
-  "flags": [],
+  "flags": [
+    {
+      "detail": "8 different repos merged their PRs",
+      "label": "Accepted contributions across many repos",
+      "points": -20,
+    },
+    {
+      "detail": "Account is 4994 days old (5+ years)",
+      "label": "Long-standing account",
+      "points": -20,
+    },
+  ],
   "profile": {
-    "age": 4993,
+    "age": 4994,
     "repos": 536,
   },
   "score": 100,
@@ -79,9 +100,15 @@ exports[`Signals > analysis 'user/claudiaschoen' 1`] = `
 exports[`Signals > analysis 'user/elenahowe' 1`] = `
 {
   "classification": "organic",
-  "flags": [],
+  "flags": [
+    {
+      "detail": "Account is 3221 days old (5+ years)",
+      "label": "Long-standing account",
+      "points": -20,
+    },
+  ],
   "profile": {
-    "age": 3220,
+    "age": 3221,
     "repos": 859,
   },
   "score": 100,
@@ -109,9 +136,15 @@ exports[`Signals > analysis 'user/robinsatterfield' 1`] = `
 exports[`Signals > analysis 'user/shellychristiansen' 1`] = `
 {
   "classification": "organic",
-  "flags": [],
+  "flags": [
+    {
+      "detail": "Account is 2353 days old (5+ years)",
+      "label": "Long-standing account",
+      "points": -20,
+    },
+  ],
   "profile": {
-    "age": 2352,
+    "age": 2353,
     "repos": 53,
   },
   "score": 100,
@@ -121,7 +154,18 @@ exports[`Signals > analysis 'user/shellychristiansen' 1`] = `
 exports[`Signals > analysis 'user/vaughnjohnston' 1`] = `
 {
   "classification": "organic",
-  "flags": [],
+  "flags": [
+    {
+      "detail": "5 different repos merged their PRs",
+      "label": "Accepted contributions across repos",
+      "points": -10,
+    },
+    {
+      "detail": "Account is 4576 days old (5+ years)",
+      "label": "Long-standing account",
+      "points": -20,
+    },
+  ],
   "profile": {
     "age": 4576,
     "repos": 30,

--- a/test/__snapshots__/signals.test.ts.snap
+++ b/test/__snapshots__/signals.test.ts.snap
@@ -24,18 +24,23 @@ exports[`Signals > analysis 'automation/joannwalsh' 1`] = `
       "label": "Established account",
       "points": -10,
     },
+    {
+      "detail": "Uneven day-of-week activity distribution suggests natural rest cycles",
+      "label": "Human activity patterns",
+      "points": -5,
+    },
   ],
   "profile": {
     "age": 1097,
     "repos": 134,
   },
-  "score": 9,
+  "score": 14,
 }
 `;
 
 exports[`Signals > analysis 'automation/reedpurdy' 1`] = `
 {
-  "classification": "mixed",
+  "classification": "organic",
   "flags": [
     {
       "detail": "13 repos forked within 24 hours",
@@ -47,30 +52,50 @@ exports[`Signals > analysis 'automation/reedpurdy' 1`] = `
       "label": "Established account",
       "points": -10,
     },
+    {
+      "detail": "77-day activity gap (bots don't take breaks)",
+      "label": "Extended activity hiatus",
+      "points": -10,
+    },
+    {
+      "detail": "Uneven day-of-week activity distribution suggests natural rest cycles",
+      "label": "Human activity patterns",
+      "points": -5,
+    },
   ],
   "profile": {
     "age": 1372,
     "repos": 125,
   },
-  "score": 59,
+  "score": 74,
 }
 `;
 
 exports[`Signals > analysis 'automation/sheilaleffler' 1`] = `
 {
-  "classification": "mixed",
+  "classification": "organic",
   "flags": [
     {
       "detail": "14/20 branch creations followed by PRs within 41s",
       "label": "Automated branch/PR workflow",
       "points": 35,
     },
+    {
+      "detail": "36-day activity gap",
+      "label": "Activity hiatus",
+      "points": -5,
+    },
+    {
+      "detail": "Uneven day-of-week activity distribution suggests natural rest cycles",
+      "label": "Human activity patterns",
+      "points": -5,
+    },
   ],
   "profile": {
     "age": 397,
     "repos": 31,
   },
-  "score": 65,
+  "score": 75,
 }
 `;
 
@@ -87,6 +112,21 @@ exports[`Signals > analysis 'user/claudiaschoen' 1`] = `
       "detail": "Account is 4994 days old (5+ years)",
       "label": "Long-standing account",
       "points": -20,
+    },
+    {
+      "detail": "6 outbound code reviews on others' PRs",
+      "label": "Code review contributor",
+      "points": -5,
+    },
+    {
+      "detail": "6 inline review comments on others' code",
+      "label": "Inline code reviewer",
+      "points": -5,
+    },
+    {
+      "detail": "Uneven day-of-week activity distribution suggests natural rest cycles",
+      "label": "Human activity patterns",
+      "points": -5,
     },
   ],
   "profile": {
@@ -105,6 +145,16 @@ exports[`Signals > analysis 'user/elenahowe' 1`] = `
       "detail": "Account is 3221 days old (5+ years)",
       "label": "Long-standing account",
       "points": -20,
+    },
+    {
+      "detail": "53 outbound code reviews on others' PRs",
+      "label": "Active code reviewer",
+      "points": -10,
+    },
+    {
+      "detail": "Uneven day-of-week activity distribution suggests natural rest cycles",
+      "label": "Human activity patterns",
+      "points": -5,
     },
   ],
   "profile": {
@@ -142,6 +192,21 @@ exports[`Signals > analysis 'user/shellychristiansen' 1`] = `
       "label": "Long-standing account",
       "points": -20,
     },
+    {
+      "detail": "37 outbound code reviews on others' PRs",
+      "label": "Active code reviewer",
+      "points": -10,
+    },
+    {
+      "detail": "15 inline review comments on others' code",
+      "label": "Frequent inline reviewer",
+      "points": -10,
+    },
+    {
+      "detail": "Uneven day-of-week activity distribution suggests natural rest cycles",
+      "label": "Human activity patterns",
+      "points": -5,
+    },
   ],
   "profile": {
     "age": 2353,
@@ -164,6 +229,26 @@ exports[`Signals > analysis 'user/vaughnjohnston' 1`] = `
       "detail": "Account is 4576 days old (5+ years)",
       "label": "Long-standing account",
       "points": -20,
+    },
+    {
+      "detail": "8 outbound code reviews on others' PRs",
+      "label": "Code review contributor",
+      "points": -5,
+    },
+    {
+      "detail": "4 inline review comments on others' code",
+      "label": "Inline code reviewer",
+      "points": -5,
+    },
+    {
+      "detail": "33-day activity gap",
+      "label": "Activity hiatus",
+      "points": -5,
+    },
+    {
+      "detail": "Uneven day-of-week activity distribution suggests natural rest cycles",
+      "label": "Human activity patterns",
+      "points": -5,
     },
   ],
   "profile": {

--- a/test/signals.test.ts
+++ b/test/signals.test.ts
@@ -462,3 +462,860 @@ describe("Repos created before AI era mitigating signal", () => {
     expect(highFlag).toBeUndefined();
   });
 });
+
+// ─── helpers for the new signal tests ────────────────────────────────────────
+
+function reviewEvent(repo: string, eventDate: string): GitHubEvent {
+  return {
+    type: "PullRequestReviewEvent",
+    created_at: eventDate,
+    repo: { id: 0, name: repo, url: "" },
+    payload: { action: "submitted" },
+  } as unknown as GitHubEvent;
+}
+
+function reviewCommentEvent(repo: string, eventDate: string): GitHubEvent {
+  return {
+    type: "PullRequestReviewCommentEvent",
+    created_at: eventDate,
+    repo: { id: 0, name: repo, url: "" },
+    payload: {},
+  } as unknown as GitHubEvent;
+}
+
+function syncEvent(repo: string, eventDate: string): GitHubEvent {
+  return {
+    type: "PullRequestEvent",
+    created_at: eventDate,
+    repo: { id: 0, name: repo, url: "" },
+    payload: { action: "synchronize" },
+  } as unknown as GitHubEvent;
+}
+
+function gistEvent(eventDate: string): GitHubEvent {
+  return {
+    type: "GistEvent",
+    created_at: eventDate,
+    repo: { id: 0, name: "gist", url: "" },
+    payload: {},
+  } as unknown as GitHubEvent;
+}
+
+function pushEventAt(repo: string, eventDate: string): GitHubEvent {
+  return {
+    type: "PushEvent",
+    created_at: eventDate,
+    repo: { id: 0, name: repo, url: "" },
+    payload: {},
+  } as unknown as GitHubEvent;
+}
+
+// ─── outbound PR review ───────────────────────────────────────────────────────
+
+describe("Outbound PR review mitigating signal", () => {
+  it("applies high mitigation (-10 pts) when 15+ outbound reviews submitted", () => {
+    const events = padToMinEvents(
+      Array.from({ length: 15 }, (_, i) =>
+        reviewEvent(`org-${i}/repo`, "2026-01-15T10:00:00Z"),
+      ),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find((f) => f.label === "Active code reviewer");
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("applies base mitigation (-5 pts) when 5–14 outbound reviews submitted", () => {
+    const events = padToMinEvents(
+      Array.from({ length: 5 }, (_, i) =>
+        reviewEvent(`org-${i}/repo`, "2026-01-15T10:00:00Z"),
+      ),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Code review contributor",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-5);
+  });
+
+  it("does not trigger when fewer than 5 outbound reviews", () => {
+    const events = padToMinEvents(
+      Array.from({ length: 4 }, (_, i) =>
+        reviewEvent(`org-${i}/repo`, "2026-01-15T10:00:00Z"),
+      ),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Active code reviewer" ||
+        f.label === "Code review contributor",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("ignores review events on own repos", () => {
+    const events = padToMinEvents(
+      Array.from({ length: 15 }, (_, i) =>
+        reviewEvent(`testuser/repo-${i}`, "2026-01-15T10:00:00Z"),
+      ),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Active code reviewer" ||
+        f.label === "Code review contributor",
+    );
+    expect(flag).toBeUndefined();
+  });
+});
+
+// ─── inline review comments ───────────────────────────────────────────────────
+
+describe("Inline review comment mitigating signal", () => {
+  it("applies high mitigation (-10 pts) when 10+ inline review comments", () => {
+    const events = padToMinEvents(
+      Array.from({ length: 10 }, (_, i) =>
+        reviewCommentEvent(`org-${i}/repo`, "2026-01-15T10:00:00Z"),
+      ),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Frequent inline reviewer",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("applies base mitigation (-5 pts) when 3–9 inline review comments", () => {
+    const events = padToMinEvents(
+      Array.from({ length: 3 }, (_, i) =>
+        reviewCommentEvent(`org-${i}/repo`, "2026-01-15T10:00:00Z"),
+      ),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find((f) => f.label === "Inline code reviewer");
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-5);
+  });
+
+  it("does not trigger when fewer than 3 inline review comments", () => {
+    const events = padToMinEvents(
+      Array.from({ length: 2 }, (_, i) =>
+        reviewCommentEvent(`org-${i}/repo`, "2026-01-15T10:00:00Z"),
+      ),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Frequent inline reviewer" ||
+        f.label === "Inline code reviewer",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("ignores inline review comments on own repos", () => {
+    const events = padToMinEvents(
+      Array.from({ length: 10 }, (_, i) =>
+        reviewCommentEvent(`testuser/repo-${i}`, "2026-01-15T10:00:00Z"),
+      ),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Frequent inline reviewer" ||
+        f.label === "Inline code reviewer",
+    );
+    expect(flag).toBeUndefined();
+  });
+});
+
+// ─── follower count ───────────────────────────────────────────────────────────
+
+describe("Follower count mitigating signal", () => {
+  it("applies high mitigation (-10 pts) when 200+ followers", () => {
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      profile: { followers: 200 },
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Established community presence",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("applies base mitigation (-5 pts) when 50–199 followers", () => {
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      profile: { followers: 50 },
+    });
+
+    const flag = result.flags.find((f) => f.label === "Community presence");
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-5);
+  });
+
+  it("does not trigger when fewer than 50 followers", () => {
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      profile: { followers: 49 },
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Established community presence" ||
+        f.label === "Community presence",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("does not trigger when profile is absent", () => {
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Established community presence" ||
+        f.label === "Community presence",
+    );
+    expect(flag).toBeUndefined();
+  });
+});
+
+// ─── identity completeness ────────────────────────────────────────────────────
+
+describe("Identity completeness mitigating signal", () => {
+  it("applies high mitigation (-10 pts) when all 5 fields filled and bio is substantive", () => {
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      profile: {
+        name: "Alice Developer",
+        company: "OSS Corp",
+        location: "Berlin, Germany",
+        bio: "Building open source software and contributing to the ecosystem.",
+        blog: "https://alice.dev",
+      },
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Complete developer identity",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("applies base mitigation (-5 pts) when 3 fields filled", () => {
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      profile: {
+        name: "Alice Developer",
+        company: "OSS Corp",
+        location: "Berlin, Germany",
+      },
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Established developer identity",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-5);
+  });
+
+  it("does not apply high mitigation when all fields filled but bio is short", () => {
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      profile: {
+        name: "Alice",
+        company: "Corp",
+        location: "Berlin",
+        bio: "Dev",
+        blog: "https://alice.dev",
+      },
+    });
+
+    const highFlag = result.flags.find(
+      (f) => f.label === "Complete developer identity",
+    );
+    expect(highFlag).toBeUndefined();
+
+    // base tier fires because 5 fields are filled (>= 3)
+    const baseFlag = result.flags.find(
+      (f) => f.label === "Established developer identity",
+    );
+    expect(baseFlag).toBeDefined();
+  });
+
+  it("does not trigger when fewer than 3 fields filled", () => {
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      profile: {
+        name: "Alice",
+        company: null,
+        location: "",
+        bio: null,
+        blog: "",
+      },
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Complete developer identity" ||
+        f.label === "Established developer identity",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("does not trigger when profile is absent", () => {
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Complete developer identity" ||
+        f.label === "Established developer identity",
+    );
+    expect(flag).toBeUndefined();
+  });
+});
+
+// ─── activity dormancy gap ────────────────────────────────────────────────────
+
+describe("Activity dormancy gap mitigating signal", () => {
+  it("applies high mitigation (-10 pts) when a 60+ day gap exists", () => {
+    // Aug 1 → Dec 1 = 122 days ≥ 60
+    const events = padToMinEvents(
+      [pushEventAt("external/repo", "2025-08-01T10:00:00Z")],
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Extended activity hiatus",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("applies base mitigation (-5 pts) when a 30–59 day gap exists", () => {
+    // Oct 20 → Dec 1 = 42 days ≥ 30
+    const events = padToMinEvents(
+      [pushEventAt("external/repo", "2025-10-20T10:00:00Z")],
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find((f) => f.label === "Activity hiatus");
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-5);
+  });
+
+  it("does not trigger when no gap exceeds 29 days", () => {
+    // padToMinEvents produces Dec 1–12, max gap = 1 day
+    const events = padToMinEvents([], "testuser");
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Extended activity hiatus" || f.label === "Activity hiatus",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("uses the largest gap in the event history", () => {
+    // Three gaps: Nov1→Dec1 (30 days), Dec1→Dec2 (1 day), Dec2→Dec3 (1 day)
+    // The 30-day gap should trigger base tier
+    const events = padToMinEvents(
+      [pushEventAt("external/repo", "2025-11-01T10:00:00Z")],
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Activity hiatus" ||
+        f.label === "Extended activity hiatus",
+    );
+    expect(flag).toBeDefined();
+  });
+});
+
+// ─── gist activity ────────────────────────────────────────────────────────────
+
+describe("Gist activity mitigating signal", () => {
+  it("applies mitigation (-5 pts) when any GistEvent is present", () => {
+    const events = padToMinEvents(
+      [gistEvent("2026-01-15T10:00:00Z")],
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find((f) => f.label === "Gist activity");
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-5);
+  });
+
+  it("does not trigger when no GistEvent is present", () => {
+    const events = padToMinEvents([], "testuser");
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find((f) => f.label === "Gist activity");
+    expect(flag).toBeUndefined();
+  });
+
+  it("only needs one GistEvent to trigger (multiple do not stack)", () => {
+    const events = padToMinEvents(
+      [
+        gistEvent("2026-01-10T10:00:00Z"),
+        gistEvent("2026-01-15T10:00:00Z"),
+        gistEvent("2026-01-20T10:00:00Z"),
+      ],
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const gistFlags = result.flags.filter((f) => f.label === "Gist activity");
+    expect(gistFlags).toHaveLength(1);
+    expect(gistFlags[0].points).toBe(-5);
+  });
+});
+
+// ─── PR iteration cycles ──────────────────────────────────────────────────────
+
+describe("PR iteration cycle mitigating signal", () => {
+  it("applies high mitigation (-10 pts) when synchronize events span 5+ external repos", () => {
+    const externalRepos = [
+      "org-a/repo-1",
+      "org-b/repo-2",
+      "org-c/repo-3",
+      "org-d/repo-4",
+      "org-e/repo-5",
+    ];
+    const events = padToMinEvents(
+      externalRepos.map((repo) => syncEvent(repo, "2026-01-15T10:00:00Z")),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Active PR iteration across many repos",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("applies base mitigation (-5 pts) when synchronize events span 2–4 external repos", () => {
+    const events = padToMinEvents(
+      [
+        syncEvent("org-a/repo-1", "2026-01-15T10:00:00Z"),
+        syncEvent("org-b/repo-2", "2026-01-15T10:00:00Z"),
+      ],
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find((f) => f.label === "Active PR iteration");
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-5);
+  });
+
+  it("does not trigger when synchronize events span only 1 external repo", () => {
+    const events = padToMinEvents(
+      [syncEvent("org-a/repo-1", "2026-01-15T10:00:00Z")],
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Active PR iteration across many repos" ||
+        f.label === "Active PR iteration",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("deduplicates: multiple synchronize events to the same repo count once", () => {
+    // 3 sync events but all to the same repo = 1 unique repo = below threshold
+    const events = padToMinEvents(
+      [
+        syncEvent("org-a/repo-1", "2026-01-10T10:00:00Z"),
+        syncEvent("org-a/repo-1", "2026-01-12T10:00:00Z"),
+        syncEvent("org-a/repo-1", "2026-01-15T10:00:00Z"),
+      ],
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Active PR iteration across many repos" ||
+        f.label === "Active PR iteration",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("ignores synchronize events on own repos", () => {
+    const events = padToMinEvents(
+      [
+        syncEvent("testuser/repo-1", "2026-01-15T10:00:00Z"),
+        syncEvent("testuser/repo-2", "2026-01-15T10:00:00Z"),
+        syncEvent("testuser/repo-3", "2026-01-15T10:00:00Z"),
+        syncEvent("testuser/repo-4", "2026-01-15T10:00:00Z"),
+        syncEvent("testuser/repo-5", "2026-01-15T10:00:00Z"),
+      ],
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Active PR iteration across many repos" ||
+        f.label === "Active PR iteration",
+    );
+    expect(flag).toBeUndefined();
+  });
+});
+
+// ─── long-span repo engagement ────────────────────────────────────────────────
+
+describe("Long-span repo engagement mitigating signal", () => {
+  it("applies high mitigation (-10 pts) when 4+ repos have 4+ month engagement span", () => {
+    // each repo has events 8 months apart (Jul 2025 and Mar 2026 = ~243 days ≥ 120)
+    const spanEvents = ["org-a/r", "org-b/r", "org-c/r", "org-d/r"].flatMap(
+      (repo) => [
+        pushEventAt(repo, "2025-07-01T10:00:00Z"),
+        pushEventAt(repo, "2026-03-01T10:00:00Z"),
+      ],
+    );
+    const events = padToMinEvents(spanEvents, "testuser");
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Deep long-term project engagement",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("applies base mitigation (-5 pts) when 2–3 repos have 4+ month engagement span", () => {
+    const spanEvents = ["org-a/r", "org-b/r"].flatMap((repo) => [
+      pushEventAt(repo, "2025-07-01T10:00:00Z"),
+      pushEventAt(repo, "2026-03-01T10:00:00Z"),
+    ]);
+    const events = padToMinEvents(spanEvents, "testuser");
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Long-term project engagement",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-5);
+  });
+
+  it("does not trigger when only 1 repo has a 4+ month span", () => {
+    const spanEvents = [
+      pushEventAt("org-a/r", "2025-07-01T10:00:00Z"),
+      pushEventAt("org-a/r", "2026-03-01T10:00:00Z"),
+    ];
+    const events = padToMinEvents(spanEvents, "testuser");
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Deep long-term project engagement" ||
+        f.label === "Long-term project engagement",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("does not count repos with a span shorter than 4 months", () => {
+    // Two repos but each only has a 2-month span (60 days < 120)
+    const spanEvents = ["org-a/r", "org-b/r"].flatMap((repo) => [
+      pushEventAt(repo, "2025-10-01T10:00:00Z"),
+      pushEventAt(repo, "2025-12-01T10:00:00Z"),
+    ]);
+    const events = padToMinEvents(spanEvents, "testuser");
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) =>
+        f.label === "Deep long-term project engagement" ||
+        f.label === "Long-term project engagement",
+    );
+    expect(flag).toBeUndefined();
+  });
+});
+
+// ─── day-of-week variance ─────────────────────────────────────────────────────
+
+describe("Day-of-week variance mitigating signal", () => {
+  // Jan 1 2026 = Thursday, so:
+  // Sun = Jan 4, Mon = Jan 5, Tue = Jan 6, Wed = Jan 7,
+  // Thu = Jan 8, Fri = Jan 9, Sat = Jan 10
+
+  it("applies mitigation (-5 pts) when activity is concentrated on weekdays (CV ≥ 0.3)", () => {
+    // 8 events each on Mon–Thu (32 total), none on Fri/Sat/Sun
+    // CV ≈ 0.87 ≥ 0.3
+    const monThu: GitHubEvent[] = [];
+    for (let week = 0; week < 4; week++) {
+      const base = 5 + week * 7; // Jan 5, 12, 19, 26 for Monday
+      monThu.push(
+        pushEventAt("org/repo", `2026-01-${String(base).padStart(2, "0")}T10:00:00Z`),     // Mon
+        pushEventAt("org/repo", `2026-01-${String(base + 1).padStart(2, "0")}T10:00:00Z`), // Tue
+        pushEventAt("org/repo", `2026-01-${String(base + 2).padStart(2, "0")}T10:00:00Z`), // Wed
+        pushEventAt("org/repo", `2026-01-${String(base + 3).padStart(2, "0")}T10:00:00Z`), // Thu
+      );
+    }
+    // 16 events so far; add 16 more for Feb to hit 32 total
+    for (let week = 0; week < 4; week++) {
+      const base = 2 + week * 7; // Feb 2, 9, 16, 23 for Monday
+      monThu.push(
+        pushEventAt("org/repo", `2026-02-${String(base).padStart(2, "0")}T10:00:00Z`),
+        pushEventAt("org/repo", `2026-02-${String(base + 1).padStart(2, "0")}T10:00:00Z`),
+        pushEventAt("org/repo", `2026-02-${String(base + 2).padStart(2, "0")}T10:00:00Z`),
+        pushEventAt("org/repo", `2026-02-${String(base + 3).padStart(2, "0")}T10:00:00Z`),
+      );
+    }
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: monThu,
+    });
+
+    const flag = result.flags.find((f) => f.label === "Human activity patterns");
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-5);
+  });
+
+  it("does not trigger when activity is evenly spread across all 7 days (CV < 0.3)", () => {
+    // 4 events per day of week = 28 total, CV = 0
+    const uniform: GitHubEvent[] = [];
+    for (let week = 0; week < 4; week++) {
+      const base = 4 + week * 7; // starts on Sunday
+      for (let d = 0; d < 7; d++) {
+        uniform.push(
+          pushEventAt("org/repo", `2026-01-${String(base + d).padStart(2, "0")}T10:00:00Z`),
+        );
+      }
+    }
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: uniform,
+    });
+
+    const flag = result.flags.find((f) => f.label === "Human activity patterns");
+    expect(flag).toBeUndefined();
+  });
+
+  it("does not trigger when fewer than 20 events (sample too small)", () => {
+    // 15 events — below DOW_EVENTS_MIN
+    const events = Array.from({ length: 15 }, (_, i) =>
+      pushEventAt("org/repo", `2026-01-${String(i + 1).padStart(2, "0")}T10:00:00Z`),
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find((f) => f.label === "Human activity patterns");
+    expect(flag).toBeUndefined();
+  });
+});

--- a/test/signals.test.ts
+++ b/test/signals.test.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it, beforeEach, afterEach, vi } from "vitest";
 import { identifyReplicant } from "../src/identify-replicant";
 import { getFixtures } from "./utils/get-fixtures";
+import type { GitHubEvent } from "../src/types";
 
 const date = new Date(2026, 2, 10, 12);
 
@@ -24,5 +25,440 @@ describe("Signals", () => {
     });
 
     expect(identity).toMatchSnapshot();
+  });
+});
+
+// Helper: build a closed+merged PullRequestEvent into an external repo
+function mergedPREvent(repo: string, eventDate: string): GitHubEvent {
+  return {
+    type: "PullRequestEvent",
+    created_at: eventDate,
+    repo: { id: 0, name: repo, url: "" },
+    payload: {
+      action: "closed",
+      pull_request: { merged: true },
+    },
+  } as unknown as GitHubEvent;
+}
+
+// Pad an event list to at least `total` events with no-op PushEvents on own repos.
+// Required because behavioral signals are gated on events.length >= MIN_EVENTS_FOR_ANALYSIS (10).
+function padToMinEvents(
+  events: GitHubEvent[],
+  accountName: string,
+  total = 12,
+): GitHubEvent[] {
+  const extra = Array.from(
+    { length: Math.max(0, total - events.length) },
+    (_, i) =>
+      ({
+        type: "PushEvent",
+        created_at: `2025-12-${String(i + 1).padStart(2, "0")}T10:00:00Z`,
+        repo: { id: 0, name: `${accountName}/own-repo`, url: "" },
+        payload: {},
+      }) as unknown as GitHubEvent,
+  );
+  return [...events, ...extra];
+}
+
+// Established contributor: account created 2015, few personal repos, lots of external PRs
+// mirrors the real false-positive pattern (high external activity + low personal repos)
+const ESTABLISHED_CREATED_AT = "2015-01-01T00:00:00Z"; // ~4000 days old at fake timer date
+const ESTABLISHED_REPOS = 3; // below PERSONAL_REPOS_LOW (5)
+
+describe("Merged external PR mitigating signal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(date);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("applies high mitigation (-20 pts) when 8+ distinct repos merged PRs", () => {
+    const externalRepos = [
+      "org-a/repo-1",
+      "org-b/repo-2",
+      "org-c/repo-3",
+      "org-d/repo-4",
+      "org-e/repo-5",
+      "org-f/repo-6",
+      "org-g/repo-7",
+      "org-h/repo-8",
+    ];
+    const events = padToMinEvents(
+      externalRepos.map((repo) => mergedPREvent(repo, "2026-01-15T10:00:00Z")),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Accepted contributions across many repos",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-20);
+  });
+
+  it("applies base mitigation (-10 pts) when 3–7 distinct repos merged PRs", () => {
+    const externalRepos = ["org-a/repo-1", "org-b/repo-2", "org-c/repo-3"];
+    const events = padToMinEvents(
+      externalRepos.map((repo) => mergedPREvent(repo, "2026-01-15T10:00:00Z")),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Accepted contributions across repos",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("does not trigger when fewer than 3 distinct repos merged PRs", () => {
+    const externalRepos = ["org-a/repo-1", "org-b/repo-2"];
+    const events = padToMinEvents(
+      externalRepos.map((repo) => mergedPREvent(repo, "2026-01-15T10:00:00Z")),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const mitigationFlag = result.flags.find(
+      (f) => f.label.startsWith("Accepted contributions"),
+    );
+    expect(mitigationFlag).toBeUndefined();
+  });
+
+  it("deduplicates: multiple merged PRs into the same repo count once", () => {
+    // 2 merged PRs into same repo = only 1 unique repo = below threshold
+    const events = [
+      mergedPREvent("org-a/repo-1", "2026-01-10T10:00:00Z"),
+      mergedPREvent("org-a/repo-1", "2026-01-15T10:00:00Z"),
+    ];
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const mitigationFlag = result.flags.find(
+      (f) => f.label.startsWith("Accepted contributions"),
+    );
+    expect(mitigationFlag).toBeUndefined();
+  });
+
+  it("counts PRs with action=merged (real-world API format)", () => {
+    const externalRepos = ["org-a/repo-1", "org-b/repo-2", "org-c/repo-3"];
+    const events = padToMinEvents(
+      externalRepos.map(
+        (repo) =>
+          ({
+            type: "PullRequestEvent",
+            created_at: "2026-01-15T10:00:00Z",
+            repo: { id: 0, name: repo, url: "" },
+            payload: { action: "merged" },
+          }) as unknown as GitHubEvent,
+      ),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Accepted contributions across repos",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("ignores own-repo PRs when account name matches repo owner", () => {
+    const ownRepos = ["testuser/repo-1", "testuser/repo-2", "testuser/repo-3"];
+    const events = padToMinEvents(
+      ownRepos.map((repo) => mergedPREvent(repo, "2026-01-15T10:00:00Z")),
+      "testuser",
+    );
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const mitigationFlag = result.flags.find(
+      (f) => f.label.startsWith("Accepted contributions"),
+    );
+    expect(mitigationFlag).toBeUndefined();
+  });
+
+  it("ignores opened PRs and closed-but-not-merged PRs", () => {
+    const events: GitHubEvent[] = [
+      // opened PR — not merged
+      {
+        type: "PullRequestEvent",
+        created_at: "2026-01-10T10:00:00Z",
+        repo: { id: 0, name: "org-a/repo-1", url: "" },
+        payload: { action: "opened" },
+      } as unknown as GitHubEvent,
+      // closed PR, not merged (rejected)
+      {
+        type: "PullRequestEvent",
+        created_at: "2026-01-11T10:00:00Z",
+        repo: { id: 0, name: "org-b/repo-2", url: "" },
+        payload: {
+          action: "closed",
+          pull_request: { merged: false },
+        },
+      } as unknown as GitHubEvent,
+      // closed PR, merged field absent
+      {
+        type: "PullRequestEvent",
+        created_at: "2026-01-12T10:00:00Z",
+        repo: { id: 0, name: "org-c/repo-3", url: "" },
+        payload: { action: "closed" },
+      } as unknown as GitHubEvent,
+    ];
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events,
+    });
+
+    const mitigationFlag = result.flags.find(
+      (f) => f.label.startsWith("Accepted contributions"),
+    );
+    expect(mitigationFlag).toBeUndefined();
+  });
+});
+
+describe("Account age mitigating signal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(date);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("applies veteran mitigation (-20 pts) when account is 5+ years old", () => {
+    const result = identifyReplicant({
+      createdAt: "2015-01-01T00:00:00Z",
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+    });
+
+    const flag = result.flags.find((f) => f.label === "Long-standing account");
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-20);
+  });
+
+  it("applies senior mitigation (-10 pts) when account is 3–4 years old", () => {
+    const result = identifyReplicant({
+      createdAt: "2022-01-01T00:00:00Z",
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+    });
+
+    const flag = result.flags.find((f) => f.label === "Established account");
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("does not apply age mitigation to young accounts (< 90 days)", () => {
+    const result = identifyReplicant({
+      createdAt: "2026-02-01T00:00:00Z",
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+    });
+
+    const mitigationFlag = result.flags.find(
+      (f) => f.label === "Long-standing account" || f.label === "Established account",
+    );
+    expect(mitigationFlag).toBeUndefined();
+  });
+
+  it("age penalty and age mitigation are mutually exclusive", () => {
+    const result = identifyReplicant({
+      createdAt: "2026-03-01T00:00:00Z",
+      reposCount: ESTABLISHED_REPOS,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+    });
+
+    const penaltyFlag = result.flags.find((f) => f.label === "Recently created");
+    const mitigationFlag = result.flags.find(
+      (f) => f.label === "Long-standing account" || f.label === "Established account",
+    );
+    expect(penaltyFlag).toBeDefined();
+    expect(mitigationFlag).toBeUndefined();
+  });
+});
+
+describe("Repos created before AI era mitigating signal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(date);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("applies high mitigation (-20 pts) when 8+ repos predate 2025", () => {
+    const repos = Array.from({ length: 8 }, (_, i) => ({
+      created_at: `${2015 + i}-01-01T00:00:00Z`,
+    }));
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: repos.length,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      repos,
+    });
+
+    const flag = result.flags.find(
+      (f) => f.label === "Pre-AI development history",
+    );
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-20);
+  });
+
+  it("applies base mitigation (-10 pts) when 3–7 repos predate 2025", () => {
+    const repos = [
+      { created_at: "2020-01-01T00:00:00Z" },
+      { created_at: "2021-06-15T00:00:00Z" },
+      { created_at: "2022-03-01T00:00:00Z" },
+    ];
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: repos.length,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      repos,
+    });
+
+    const flag = result.flags.find((f) => f.label === "Pre-AI activity");
+    expect(flag).toBeDefined();
+    expect(flag?.points).toBe(-10);
+  });
+
+  it("does not trigger when fewer than 3 repos predate 2025", () => {
+    const repos = [
+      { created_at: "2020-01-01T00:00:00Z" },
+      { created_at: "2021-06-15T00:00:00Z" },
+    ];
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: repos.length,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      repos,
+    });
+
+    const mitigationFlag = result.flags.find(
+      (f) =>
+        f.label === "Pre-AI development history" || f.label === "Pre-AI activity",
+    );
+    expect(mitigationFlag).toBeUndefined();
+  });
+
+  it("does not trigger when repos field is absent", () => {
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: 10,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+    });
+
+    const mitigationFlag = result.flags.find(
+      (f) =>
+        f.label === "Pre-AI development history" || f.label === "Pre-AI activity",
+    );
+    expect(mitigationFlag).toBeUndefined();
+  });
+
+  it("does not trigger when all repos postdate 2025", () => {
+    const repos = [
+      { created_at: "2025-01-01T00:00:00Z" },
+      { created_at: "2025-06-15T00:00:00Z" },
+      { created_at: "2026-01-01T00:00:00Z" },
+    ];
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: repos.length,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      repos,
+    });
+
+    const mitigationFlag = result.flags.find(
+      (f) =>
+        f.label === "Pre-AI development history" || f.label === "Pre-AI activity",
+    );
+    expect(mitigationFlag).toBeUndefined();
+  });
+
+  it("counts only repos with created_at before 2025 (mixed dates)", () => {
+    const repos = [
+      { created_at: "2020-01-01T00:00:00Z" },
+      { created_at: "2021-06-15T00:00:00Z" },
+      { created_at: "2022-03-01T00:00:00Z" },
+      { created_at: "2025-01-01T00:00:00Z" },
+      { created_at: "2025-06-15T00:00:00Z" },
+      { created_at: "2026-01-01T00:00:00Z" },
+    ];
+
+    const result = identifyReplicant({
+      createdAt: ESTABLISHED_CREATED_AT,
+      reposCount: repos.length,
+      accountName: "testuser",
+      events: padToMinEvents([], "testuser"),
+      repos,
+    });
+
+    // 3 pre-2025 repos → base tier only
+    const baseFlag = result.flags.find((f) => f.label === "Pre-AI activity");
+    expect(baseFlag).toBeDefined();
+    expect(baseFlag?.points).toBe(-10);
+
+    const highFlag = result.flags.find(
+      (f) => f.label === "Pre-AI development history",
+    );
+    expect(highFlag).toBeUndefined();
   });
 });


### PR DESCRIPTION
Adds nine mitigating signals that subtract from the raw penalty score before the final human-score inversion. Each targets a behavioral pattern bots skip because it has no spam value or requires genuine cognitive engagement.

## Signals added

| Signal | Source | Rationale |
|--------|--------|-----------|
| Outbound PR reviews | `PullRequestReviewEvent` on external repos | Reviewing others' code requires reading unfamiliar diffs |
| Inline review comments | `PullRequestReviewCommentEvent` on external repos | Commenting on specific diff lines requires understanding the code |
| Follower count | `profile.followers` | Hard to inflate organically post-2022 |
| Identity completeness | `profile` fields (name, company, location, bio, blog) | Full profiles are high friction for bot farms |
| Activity dormancy gaps | Largest gap between event timestamps | Bots run continuously; 30- and 60-day gaps are a human pattern |
| Gist activity | `GistEvent` | Zero spam value for bots |
| PR iteration cycles | `synchronize` action on external `PullRequestEvent` | Pushing follow-up commits after review is hard to fake at scale |
| Long-span repo engagement | Same repo events 120+ days apart | Returning to a repo months later signals sustained interest |
| Day-of-week variance | CV ≥ 0.3 across the 7-day distribution | Perfectly uniform activity is a bot pattern |

## Implementation

- All signals deduplicate by repo name, matching the existing merged-PR signal pattern
- Own-repo events are excluded from review and comment signals (same `repoOwner === userLogin` guard used elsewhere)
- Profile-dependent signals silently no-op when the optional `profile` field is not passed by the caller
- 36 new `CONFIG` constants for all thresholds
- 9 new `describe` blocks in `test/signals.test.ts`; 61 tests total, all passing